### PR TITLE
Adds the support for Laravel v8.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "illuminate/support": "^5.8|^6.0|^7.0|^8.0",
         "espresso-dev/instagram-basic-display-php": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^8.0||^9.0",
         "orchestra/testbench": "^5.1"
     },
     "autoload" : {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "illuminate/support": "^5.8|^6.0|^7.0",
+        "illuminate/support": "^5.8|^6.0|^7.0|^8.0",
         "espresso-dev/instagram-basic-display-php": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adds bumps up the version of laravel & phpunit to allow the installation of the package in Laravel v8.0 applications